### PR TITLE
enable provider in git commit scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Please note that this package shows emoji suggestions in the scope below.
 * .source.gfm
 * .text.html
 * .text.plain
+* .text.git-commit
 * .comment
 * .string
 

--- a/lib/emojis-provider.coffee
+++ b/lib/emojis-provider.coffee
@@ -4,7 +4,7 @@ fuzzaldrin = require('fuzzaldrin')
 emoji = require('emoji-images')
 
 module.exports =
-  selector: '.source.gfm, .text.html, .text.plain, .comment, .string'
+  selector: '.source.gfm, .text.html, .text.plain, .text.git-commit, .comment, .string'
 
   wordRegex: /::?[\w\d_\+-]+$/
   emojiFolder: 'atom://autocomplete-emojis/node_modules/emoji-images/pngs'


### PR DESCRIPTION
Would make sense since [atom](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#git-commit-messages) encourages the usage of emojis in commit messages.
