### PR TITLE
Update dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autocomplete-emojis",
   "main": "./lib/autocomplete-emojis",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Adds emoji autocompletion to autocomplete+",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "fuzzaldrin": "^2.1.0"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-apm": "0.0.1",
-    "grunt-coffee-jshint": "^0.2.1",
-    "grunt-contrib-watch": "^0.6.1",
+    "grunt": "^1.0.1",
+    "grunt-apm": "^1.0.1",
+    "grunt-coffee-jshint": "^0.3.0",
+    "grunt-contrib-watch": "^1.0.0",
     "load-grunt-tasks": "^3.1.0",
     "request": "^2.55.0",
     "time-grunt": "^1.0.0"


### PR DESCRIPTION
I think this resolves the issue I opened (https://github.com/atom/autocomplete-emojis/issues/8). After updating `grunt-apm` I was able to successfully `apm link` the package. I am just learning about semver, packages, etc, LMK if I missed a step.

Thanks!
