### PR TITLE
Add language-markdown support 

### DIFF
--- a/lib/emojis-provider.coffee
+++ b/lib/emojis-provider.coffee
@@ -4,7 +4,7 @@ fuzzaldrin = require('fuzzaldrin')
 emoji = require('emoji-images')
 
 module.exports =
-  selector: '.source.gfm, .text.html, .text.slim, .text.plain, .text.git-commit, .comment, .string, .source.emojicode'
+  selector: '.source.gfm, .text.md .text.html, .text.slim, .text.plain, .text.git-commit, .comment, .string, .source.emojicode'
 
   wordRegex: /::?[\w\d_\+-]+$/
   emojiFolder: 'atom://autocomplete-emojis/node_modules/emoji-images/pngs'

--- a/lib/emojis-provider.coffee
+++ b/lib/emojis-provider.coffee
@@ -4,7 +4,7 @@ fuzzaldrin = require('fuzzaldrin')
 emoji = require('emoji-images')
 
 module.exports =
-  selector: '.source.gfm, .text.md .text.html, .text.slim, .text.plain, .text.git-commit, .comment, .string, .source.emojicode'
+  selector: '.source.gfm, .text.md, .text.html, .text.slim, .text.plain, .text.git-commit, .comment, .string, .source.emojicode'
 
   wordRegex: /::?[\w\d_\+-]+$/
   emojiFolder: 'atom://autocomplete-emojis/node_modules/emoji-images/pngs'


### PR DESCRIPTION
[language-markdown](https://github.com/burodepeper/language-markdown) uses `text.md`, rather than `source.gfm`, so this adds the required scope for it to work in that syntax.
