### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+
+/doc export-ignore
+/spec export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/Gruntfile.js export-ignore
+/build-package-travis-osx.sh export-ignore
+/update.coffee export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, screenshots, tests, .travis.yml, etc).

Happy Hacktoberfest!